### PR TITLE
Handle parsing Maven version ranges

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -24,6 +24,12 @@ maven_jar(
 )
 
 maven_jar(
+    name = "maven_artifact",
+    artifact = "org.apache.maven:maven-artifact:3.5.0",
+)
+
+# Testing
+maven_jar(
     name = "org_mockito",
     artifact = "org.mockito:mockito-all:1.9.5",
 )

--- a/generate_workspace/src/main/java/com/google/devtools/build/workspace/maven/BUILD
+++ b/generate_workspace/src/main/java/com/google/devtools/build/workspace/maven/BUILD
@@ -18,6 +18,7 @@ java_library(
         "//third_party:maven_model",
         "@guava//jar",
         "@jsr305//jar",
+        "@maven_artifact//jar",
         "@plexus_component_annotations//jar",
     ],
 )

--- a/generate_workspace/src/main/java/com/google/devtools/build/workspace/maven/DefaultModelResolver.java
+++ b/generate_workspace/src/main/java/com/google/devtools/build/workspace/maven/DefaultModelResolver.java
@@ -124,6 +124,12 @@ public class DefaultModelResolver implements ModelResolver {
       String url, String groupId, String artifactId, String version)
       throws UnresolvableModelException {
     try {
+      version = Resolver.resolveVersion(groupId, artifactId, version);
+    } catch (Resolver.InvalidArtifactCoordinateException e) {
+      throw new UnresolvableModelException(
+          "Unable to resolve version", groupId, artifactId, version, e);
+    }
+    try {
       if (!url.endsWith("/")) {
         url += "/";
       }

--- a/generate_workspace/src/test/java/com/google/devtools/build/workspace/maven/ResolverTest.java
+++ b/generate_workspace/src/test/java/com/google/devtools/build/workspace/maven/ResolverTest.java
@@ -28,6 +28,9 @@ import java.util.Collection;
  */
 @RunWith(JUnit4.class)
 public class ResolverTest {
+  private static final String GROUP_ID = "x";
+  private static final String ARTIFACT_ID = "y";
+
   @Test
   public void testGetSha1Url() throws Exception {
     assertThat(Resolver.getSha1Url("http://example.com/foo.pom", "jar"))
@@ -64,5 +67,39 @@ public class ResolverTest {
     assertThat(Resolver.extractSha1(
          "83cd2cd674a217ade95a4bb83a8a14f351f48bd0  /home/maven/repository-staging/to-ibiblio/maven2/antlr/antlr/2.7.7/antlr-2.7.7.jar"))
         .isEqualTo("83cd2cd674a217ade95a4bb83a8a14f351f48bd0");
+  }
+
+  @Test
+  public void basicVersion() throws Exception {
+    assertThat(Resolver.resolveVersion(ARTIFACT_ID, GROUP_ID, "1.2.3"))
+        .isEqualTo("1.2.3");
+  }
+
+  @Test
+  public void exactVersion() throws Exception {
+    assertThat(Resolver.resolveVersion(ARTIFACT_ID, GROUP_ID, "[1.2.3]"))
+        .isEqualTo("1.2.3");
+  }
+
+  @Test
+  public void versionRange() throws Exception {
+    assertThat(Resolver.resolveVersion(ARTIFACT_ID, GROUP_ID, "[1.2.3,1.2.5]"))
+        .isEqualTo("1.2.5");
+  }
+
+  @Test
+  public void versionRangeExclusive() throws Exception {
+    assertThat(Resolver.resolveVersion(ARTIFACT_ID, GROUP_ID, "[1.2.3,1.2.5)"))
+        .isEqualTo("1.2.3");
+  }
+
+  @Test(expected = Resolver.InvalidArtifactCoordinateException.class)
+  public void versionRangeAllExclusive() throws Exception {
+    Resolver.resolveVersion(ARTIFACT_ID, GROUP_ID, "(1.2.3,1.2.5)");
+  }
+
+  @Test(expected = Resolver.InvalidArtifactCoordinateException.class)
+  public void unparsableVersion() throws Exception {
+    Resolver.resolveVersion(ARTIFACT_ID, GROUP_ID, "[1.2.3");
   }
 }


### PR DESCRIPTION
This isn't very smart and still won't cover specs that require
a remote lookup (e.g., (1.2.3,1.2.5)), but it eliminates all
warnings mentioned in https://github.com/bazelbuild/bazel/issues/1794
and https://github.com/bazelbuild/bazel/issues/3089.

Check out the test for examples of version ranges.