### PR TITLE
Print currently downloaded maven jar to console

### DIFF
--- a/generate_workspace/src/main/java/com/google/devtools/build/workspace/maven/Resolver.java
+++ b/generate_workspace/src/main/java/com/google/devtools/build/workspace/maven/Resolver.java
@@ -189,6 +189,8 @@ public class Resolver {
     if (model == null) {
       return;
     }
+    logger.info("\tDownloading pom for " + model.getGroupId() + ":"
+            + model.getArtifactId() + ":" + model.getVersion());
     for (Repository repo : model.getRepositories()) {
       modelResolver.addRepository(repo);
     }


### PR DESCRIPTION
Simple change to print currently downloaded maven jar to console.


```
____Running command line: bazel-bin/generate_workspace/generate_workspace '--artifact=org.powermock:powermock-module-junit4:1.5.1'

    Downloading maven artifact org.powermock:powermock-module-junit4:1.5.1
    Downloading maven artifact junit:junit:4.11
    Downloading maven artifact org.hamcrest:hamcrest-core:1.3
    Downloading maven artifact org.powermock:powermock-module-junit4-common:1.5.1
    Downloading maven artifact org.powermock:powermock-core:1.5.1
    Downloading maven artifact org.powermock:powermock-reflect:1.5.1
    Downloading maven artifact org.objenesis:objenesis:1.2
    Downloading maven artifact org.javassist:javassist:3.18.0-GA
Wrote /private/var/tmp/_bazel_petroseskinder/f4ae163fe842998e2d78cf9f858a5836/execroot/migration-tooling/bazel-out/local-fastbuild/bin/generate_workspace/generate_workspace.runfiles/__main__/generate_workspace.bzl
```
reviewer: @kchodorow 
cc: @hhclam