### PR TITLE
Fix jcommander artifact parsing so that it supports version ranges.

### DIFF
--- a/generate_workspace/src/main/java/com/google/devtools/build/workspace/GenerateWorkspaceOptions.java
+++ b/generate_workspace/src/main/java/com/google/devtools/build/workspace/GenerateWorkspaceOptions.java
@@ -15,9 +15,11 @@
 package com.google.devtools.build.workspace;
 
 import com.beust.jcommander.Parameter;
-
 import com.beust.jcommander.Parameters;
+import com.beust.jcommander.converters.IParameterSplitter;
+
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -40,6 +42,7 @@ public class GenerateWorkspaceOptions {
 
   @Parameter(
       names = {"--artifact", "-a"},
+      splitter = NoSplitter.class,
       description = "Maven artifact coordinates (e.g. groupId:artifactId:version)."
   )
   public List<String> artifacts = new ArrayList<>();
@@ -58,4 +61,19 @@ public class GenerateWorkspaceOptions {
       + " file that can be loaded from hand-written WORKSPACE and BUILD files."
   )
   public boolean directToWorkspace = false;
+
+
+  /**
+   * Jcommander defaults to splitting each parameter by comma. For example,
+   * --a=group:artifact:[x1,x2] is parsed as two items 'group:artifact:[x1' and 'x2]',
+   * instead of the intended 'group:artifact:[x1,x2]'
+   *
+   * For more information: http://jcommander.org/#_splitting
+   */
+  private static class NoSplitter implements IParameterSplitter {
+    @Override
+    public List<String> split(String value) {
+      return Arrays.asList(value);
+    }
+  }
 }

--- a/generate_workspace/src/test/java/com/google/devtools/build/workspace/GenerateWorkspaceOptionsTest.java
+++ b/generate_workspace/src/test/java/com/google/devtools/build/workspace/GenerateWorkspaceOptionsTest.java
@@ -41,4 +41,21 @@ public class GenerateWorkspaceOptionsTest {
     optionParser.parse("--artifact", "foo:bar:1.2.3");
     assertThat(options.artifacts).contains("foo:bar:1.2.3");
   }
+
+  @Test
+  public void noCommaDelimiter() throws Exception {
+    GenerateWorkspaceOptions options = new GenerateWorkspaceOptions();
+    JCommander optionParser = JCommander.newBuilder().addObject(options).build();
+    optionParser.parse("--artifact", "foo:bar:[1.2.3,)");
+    assertThat(options.artifacts).contains("foo:bar:[1.2.3,)");
+  }
+
+  @Test
+  public void multipleArtifacts() throws Exception {
+    GenerateWorkspaceOptions options = new GenerateWorkspaceOptions();
+    JCommander optionParser = JCommander.newBuilder().addObject(options).build();
+    optionParser.parse("--artifact", "a:b1:[1.2,2.0]", "--artifact", "a:b2:[1.0,2.0)");
+    assertThat(options.artifacts).containsExactly("a:b1:[1.2,2.0]", "a:b2:[1.0,2.0)");
+  }
+
 }


### PR DESCRIPTION
Previously, jcommander would parse `--a=group:artifact:[1.0,2.0]`
as {"group:artifact:[1.0", "2.0]"} rather than {"group:artifact:[1.0,2.0]"}.

jcommander defaults to splitting by comma, which we don't want.

reviewer:@kchodorow 
cc:@hhclam, @cgrushko, @jin