### PR TITLE
Allow aliasing rules that are already defined elsewhere

### DIFF
--- a/generate_workspace/src/main/java/com/google/devtools/build/workspace/BUILD
+++ b/generate_workspace/src/main/java/com/google/devtools/build/workspace/BUILD
@@ -4,7 +4,6 @@ java_library(
     visibility = ["//generate_workspace:__subpackages__"],
     deps = [
         "//generate_workspace/src/main/java/com/google/devtools/build/workspace/maven",
-        "//generate_workspace/src/main/java/com/google/devtools/build/workspace/maven:rule",
         "//generate_workspace/src/main/java/com/google/devtools/build/workspace/output",
         "//third_party:aether",
         "//third_party/jcommander",

--- a/generate_workspace/src/main/java/com/google/devtools/build/workspace/GenerateWorkspace.java
+++ b/generate_workspace/src/main/java/com/google/devtools/build/workspace/GenerateWorkspace.java
@@ -19,6 +19,7 @@ import com.beust.jcommander.ParameterException;
 import com.google.common.collect.Lists;
 import com.google.devtools.build.workspace.maven.DefaultModelResolver;
 import com.google.devtools.build.workspace.maven.Resolver;
+import com.google.devtools.build.workspace.maven.Rule;
 import com.google.devtools.build.workspace.output.AbstractWriter;
 import com.google.devtools.build.workspace.output.BzlWriter;
 import com.google.devtools.build.workspace.output.WorkspaceWriter;
@@ -57,7 +58,7 @@ public class GenerateWorkspace {
 
     try {
       GenerateWorkspace workspaceFileGenerator = new GenerateWorkspace(
-          options.outputDir, options.directToWorkspace);
+          options.outputDir, options.directToWorkspace, options.aliases);
       workspaceFileGenerator.generateFromPom(options.mavenProjects);
       workspaceFileGenerator.generateFromArtifacts(options.artifacts);
       workspaceFileGenerator.writeResults();
@@ -67,8 +68,9 @@ public class GenerateWorkspace {
     }
   }
 
-  private GenerateWorkspace(String outputDirStr, boolean directToWorkspace) throws IOException {
-    this.resolver = new Resolver(new DefaultModelResolver());
+  private GenerateWorkspace(String outputDirStr, boolean directToWorkspace, List<Rule> aliases)
+      throws IOException {
+    this.resolver = new Resolver(new DefaultModelResolver(), aliases);
     this.inputs = Lists.newArrayList();
     this.resultWriter = directToWorkspace
         ? new WorkspaceWriter(outputDirStr)

--- a/generate_workspace/src/main/java/com/google/devtools/build/workspace/maven/BUILD
+++ b/generate_workspace/src/main/java/com/google/devtools/build/workspace/maven/BUILD
@@ -1,35 +1,17 @@
 java_library(
     name = "maven",
-    srcs = [
-        "DefaultModelResolver.java",
-        "Resolver.java",
-    ],
-    visibility = [
-        "//generate_workspace/src/main/java/com/google/devtools/build/workspace:__pkg__",
-        "//generate_workspace/src/test:__subpackages__",
-    ],
+    srcs = glob(["*.java"]),
+    visibility = ["//generate_workspace/src:__subpackages__"],
     runtime_deps = [
         "@org_codehaus_plexus_plexus_interpolation//jar",
         "@org_codehaus_plexus_plexus_utils//jar",
     ],
     deps = [
-        ":rule",
         "//third_party:aether",
         "//third_party:maven_model",
         "@com_google_code_findbugs_jsr305//jar",
         "@com_google_guava_guava//jar",
         "@org_apache_maven_maven_artifact//jar",
         "@org_codehaus_plexus_plexus_component_annotations//jar",
-    ],
-)
-
-java_library(
-    name = "rule",
-    srcs = ["Rule.java"],
-    visibility = ["//generate_workspace/src:__subpackages__"],
-    deps = [
-        "//third_party:aether",
-        "//third_party:maven_model",
-        "@com_google_guava_guava//jar",
     ],
 )

--- a/generate_workspace/src/main/java/com/google/devtools/build/workspace/maven/Resolver.java
+++ b/generate_workspace/src/main/java/com/google/devtools/build/workspace/maven/Resolver.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Sets;
 import com.google.common.io.CharStreams;
 
 import java.lang.invoke.MethodHandles;
+import java.util.List;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
 import org.apache.maven.artifact.versioning.InvalidVersionSpecificationException;
@@ -62,13 +63,13 @@ public class Resolver {
   /**
    * Exception thrown if an artifact coordinate could not be parsed.
    */
-  static class InvalidArtifactCoordinateException extends Exception {
+  public static class InvalidArtifactCoordinateException extends Exception {
     InvalidArtifactCoordinateException(String message) {
       super(message);
     }
   }
   
-  static Artifact getArtifact(String atrifactCoords)
+  public static Artifact getArtifact(String atrifactCoords)
       throws InvalidArtifactCoordinateException {
     try {
       return new DefaultArtifact(atrifactCoords);
@@ -138,9 +139,10 @@ public class Resolver {
   // Mapping of maven_jar name to Rule.
   private final Map<String, Rule> deps;
 
-  public Resolver(DefaultModelResolver resolver) {
+  public Resolver(DefaultModelResolver resolver, List<Rule> aliases) {
     this.deps = Maps.newHashMap();
     this.modelResolver = resolver;
+    aliases.forEach(alias -> addArtifact(alias, TOP_LEVEL_ARTIFACT));
   }
 
   /**

--- a/generate_workspace/src/main/java/com/google/devtools/build/workspace/output/AbstractWriter.java
+++ b/generate_workspace/src/main/java/com/google/devtools/build/workspace/output/AbstractWriter.java
@@ -37,6 +37,11 @@ public abstract class AbstractWriter {
   }
 
   protected String formatMavenJar(Rule rule, String ruleName, String indent) {
+    if (rule.aliased()) {
+      // If the rule was aliased, then it is already declared somewhere else and we don't need to
+      // declare it again.
+      return "";
+    }
     StringBuilder builder = new StringBuilder();
     for (String parent : rule.getParents()) {
       builder.append(indent).append("# ").append(parent).append("\n");

--- a/generate_workspace/src/main/java/com/google/devtools/build/workspace/output/BUILD
+++ b/generate_workspace/src/main/java/com/google/devtools/build/workspace/output/BUILD
@@ -3,6 +3,6 @@ java_library(
     srcs = glob(["*.java"]),
     visibility = ["//generate_workspace/src:__subpackages__"],
     deps = [
-        "//generate_workspace/src/main/java/com/google/devtools/build/workspace/maven:rule",
+        "//generate_workspace/src/main/java/com/google/devtools/build/workspace/maven",
     ],
 )

--- a/generate_workspace/src/test/java/com/google/devtools/build/workspace/BUILD
+++ b/generate_workspace/src/test/java/com/google/devtools/build/workspace/BUILD
@@ -3,6 +3,7 @@ java_test(
     srcs = ["GenerateWorkspaceOptionsTest.java"],
     deps = [
         "//generate_workspace/src/main/java/com/google/devtools/build/workspace",
+        "//generate_workspace/src/main/java/com/google/devtools/build/workspace/maven",
         "//third_party/jcommander",
         "@com_google_truth_truth//jar",
         "@junit_junit//jar",

--- a/generate_workspace/src/test/java/com/google/devtools/build/workspace/GenerateWorkspaceOptionsTest.java
+++ b/generate_workspace/src/test/java/com/google/devtools/build/workspace/GenerateWorkspaceOptionsTest.java
@@ -17,6 +17,7 @@ package com.google.devtools.build.workspace;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.beust.jcommander.JCommander;
+import com.google.devtools.build.workspace.maven.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -56,6 +57,38 @@ public class GenerateWorkspaceOptionsTest {
     JCommander optionParser = JCommander.newBuilder().addObject(options).build();
     optionParser.parse("--artifact", "a:b1:[1.2,2.0]", "--artifact", "a:b2:[1.0,2.0)");
     assertThat(options.artifacts).containsExactly("a:b1:[1.2,2.0]", "a:b2:[1.0,2.0)");
+  }
+
+  @Test
+  public void alias() throws Exception {
+    GenerateWorkspaceOptions options = new GenerateWorkspaceOptions();
+    JCommander optionParser = JCommander.newBuilder().addObject(options).build();
+    optionParser.parse("--declare=a:b=c");
+    assertThat(options.aliases).hasSize(1);
+    Rule aliasedRule = options.aliases.get(0);
+    assertThat(aliasedRule.name()).isEqualTo("c");
+    assertThat(aliasedRule.toMavenArtifactString()).isEqualTo("a:b:0");
+  }
+
+  @Test
+  public void versionedAlias() throws Exception {
+    GenerateWorkspaceOptions options = new GenerateWorkspaceOptions();
+    JCommander optionParser = JCommander.newBuilder().addObject(options).build();
+    optionParser.parse("--declare=a:b:1.2.3=c");
+    assertThat(options.aliases).hasSize(1);
+    Rule aliasedRule = options.aliases.get(0);
+    assertThat(aliasedRule.name()).isEqualTo("c");
+    assertThat(aliasedRule.toMavenArtifactString()).isEqualTo("a:b:1.2.3");
+  }
+
+  @Test
+  public void declareDefault() throws Exception {
+    GenerateWorkspaceOptions options = new GenerateWorkspaceOptions();
+    JCommander optionParser = JCommander.newBuilder().addObject(options).build();
+    optionParser.parse("--declare=a:b");
+    assertThat(options.aliases).hasSize(1);
+    Rule aliasedRule = options.aliases.get(0);
+    assertThat(aliasedRule.name()).isEqualTo("a_b");
   }
 
 }

--- a/generate_workspace/src/test/java/com/google/devtools/build/workspace/maven/BUILD
+++ b/generate_workspace/src/test/java/com/google/devtools/build/workspace/maven/BUILD
@@ -3,7 +3,6 @@ java_test(
     srcs = ["RuleTest.java"],
     deps = [
         "//generate_workspace/src/main/java/com/google/devtools/build/workspace/maven",
-        "//generate_workspace/src/main/java/com/google/devtools/build/workspace/maven:rule",
         "@com_google_truth_truth//jar",
         "@junit_junit//jar",
     ],
@@ -14,7 +13,6 @@ java_test(
     srcs = ["ResolverTest.java"],
     deps = [
         "//generate_workspace/src/main/java/com/google/devtools/build/workspace/maven",
-        "//generate_workspace/src/main/java/com/google/devtools/build/workspace/maven:rule",
         "//third_party:aether",
         "//third_party:maven_model",
         "@com_google_guava_guava//jar",

--- a/generate_workspace/src/test/java/com/google/devtools/build/workspace/output/BUILD
+++ b/generate_workspace/src/test/java/com/google/devtools/build/workspace/output/BUILD
@@ -3,12 +3,12 @@ java_test(
     srcs = ["WorkspaceWriterTest.java"],
     deps = [
         "//generate_workspace/src/main/java/com/google/devtools/build/workspace",
-        "//generate_workspace/src/main/java/com/google/devtools/build/workspace/maven:rule",
+        "//generate_workspace/src/main/java/com/google/devtools/build/workspace/maven",
         "//generate_workspace/src/main/java/com/google/devtools/build/workspace/output",
         "//third_party:aether",
         "//third_party:maven_model",
-        "@com_google_truth_truth//jar",
         "@com_google_guava_guava//jar",
+        "@com_google_truth_truth//jar",
         "@junit_junit//jar",
     ],
 )
@@ -17,11 +17,11 @@ java_test(
     name = "BzlWriterTest",
     srcs = ["BzlWriterTest.java"],
     deps = [
-        "//generate_workspace/src/main/java/com/google/devtools/build/workspace/maven:rule",
+        "//generate_workspace/src/main/java/com/google/devtools/build/workspace/maven",
         "//generate_workspace/src/main/java/com/google/devtools/build/workspace/output",
         "//third_party:aether",
-        "@com_google_truth_truth//jar",
         "@com_google_guava_guava//jar",
+        "@com_google_truth_truth//jar",
         "@junit_junit//jar",
     ],
 )

--- a/generate_workspace/src/test/java/com/google/devtools/build/workspace/output/BzlWriterTest.java
+++ b/generate_workspace/src/test/java/com/google/devtools/build/workspace/output/BzlWriterTest.java
@@ -64,4 +64,19 @@ public class BzlWriterTest {
         + "      ],\n"
         + "  )\n");
   }
+
+  @Test
+  public void writeAlias() throws Exception {
+    BzlWriter writer = new BzlWriter(System.getenv("TEST_TMPDIR"));
+    writer.write(
+        ImmutableList.of(), ImmutableList.of(new Rule(new DefaultArtifact("x:y:1.2.3"), "z")));
+    String fileContents = Files.toString(
+        new File(System.getenv("TEST_TMPDIR") + "/generate_workspace.bzl"),
+        Charset.defaultCharset());
+    assertThat(fileContents).doesNotContain("x:y:1.2.3");
+    assertThat(fileContents).contains(
+        "      exports = [\n"
+        + "          \"@z//jar\",\n"
+        + "      ],\n");
+  }
 }


### PR DESCRIPTION
Adds a `--declare` flag that lets you create mappings between Maven artifacts and the name you want generate_workspace to use for them, e.g.,

```
generate_workspace --declare=com.google:guava=my_guava --artifact=com.google:google-cloud-logging:1.2.3
```

Then any jars that depend on com.google:guava will assume that there a remote repository called "my_guava" that's already declared.

Relevant to #24.