### PR TITLE
Print out args so it's easy to rerun generate_workspace

### DIFF
--- a/generate_workspace/src/main/java/com/google/devtools/build/workspace/GenerateWorkspace.java
+++ b/generate_workspace/src/main/java/com/google/devtools/build/workspace/GenerateWorkspace.java
@@ -57,7 +57,7 @@ public class GenerateWorkspace {
 
     try {
       GenerateWorkspace workspaceFileGenerator = new GenerateWorkspace(
-          options.outputDir, options.directToWorkspace);
+          args, options.outputDir, options.directToWorkspace);
       workspaceFileGenerator.generateFromPom(options.mavenProjects);
       workspaceFileGenerator.generateFromArtifacts(options.artifacts);
       workspaceFileGenerator.writeResults();
@@ -67,12 +67,13 @@ public class GenerateWorkspace {
     }
   }
 
-  private GenerateWorkspace(String outputDirStr, boolean directToWorkspace) throws IOException {
+  private GenerateWorkspace(String[] args, String outputDirStr, boolean directToWorkspace)
+      throws IOException {
     this.resolver = new Resolver(new DefaultModelResolver());
     this.inputs = Lists.newArrayList();
     this.resultWriter = directToWorkspace
-        ? new WorkspaceWriter(outputDirStr)
-        : new BzlWriter(outputDirStr);
+        ? new WorkspaceWriter(args, outputDirStr)
+        : new BzlWriter(args, outputDirStr);
   }
 
   private void generateFromPom(List<String> projects) {

--- a/generate_workspace/src/main/java/com/google/devtools/build/workspace/output/AbstractWriter.java
+++ b/generate_workspace/src/main/java/com/google/devtools/build/workspace/output/AbstractWriter.java
@@ -28,8 +28,9 @@ public abstract class AbstractWriter {
   /**
    * Writes the list of sources as a comment to outputStream.
    */
-  void writeHeader(PrintStream outputStream, List<String> sources) {
+  void writeHeader(PrintStream outputStream, String[] argv, List<String> sources) {
     outputStream.println("# The following dependencies were calculated from:");
+    outputStream.println("# generate_workspace " + String.join(" ", argv));
     for (String header : sources) {
       outputStream.println("# " + header);
     }

--- a/generate_workspace/src/main/java/com/google/devtools/build/workspace/output/BzlWriter.java
+++ b/generate_workspace/src/main/java/com/google/devtools/build/workspace/output/BzlWriter.java
@@ -32,10 +32,12 @@ public class BzlWriter extends AbstractWriter {
   private final static Logger logger = Logger.getLogger(
       MethodHandles.lookup().lookupClass().getName());
 
+  private final String[] argv;
   private final Path generatedFile;
 
-  public BzlWriter(String outputDirStr) {
-    generatedFile = Paths.get(outputDirStr).resolve("generate_workspace.bzl");
+  public BzlWriter(String[] argv, String outputDirStr) {
+    this.argv = argv;
+    this.generatedFile = Paths.get(outputDirStr).resolve("generate_workspace.bzl");
   }
 
   @Override
@@ -65,7 +67,7 @@ public class BzlWriter extends AbstractWriter {
             + "# For either, make sure that there is a BUILD file in your top-level directory, so"
             + " that //:generate_workspace.bzl resolves correctly.\n\n"
     );
-    writeHeader(outputStream, sources);
+    writeHeader(outputStream, argv, sources);
     outputStream.println("def generated_maven_jars():");
     if (rules.isEmpty()) {
       outputStream.println("  pass\n");

--- a/generate_workspace/src/main/java/com/google/devtools/build/workspace/output/WorkspaceWriter.java
+++ b/generate_workspace/src/main/java/com/google/devtools/build/workspace/output/WorkspaceWriter.java
@@ -36,10 +36,12 @@ public class WorkspaceWriter extends AbstractWriter {
   private final static Logger logger = Logger.getLogger(
       MethodHandles.lookup().lookupClass().getName());
 
+  private final String[] args;
   private final File workspaceFile;
   private final File buildFile;
 
-  public WorkspaceWriter(String outputDirStr) throws IOException {
+  public WorkspaceWriter(String[] args, String outputDirStr) throws IOException {
+    this.args = args;
     Path outputDir;
     if (outputDirStr.isEmpty()) {
       outputDir = Files.createTempDirectory("generate_workspace");
@@ -83,7 +85,7 @@ public class WorkspaceWriter extends AbstractWriter {
    */
   public void writeWorkspace(PrintStream outputStream, List<String> sources,
       Collection<Rule> rules) {
-    writeHeader(outputStream, sources);
+    writeHeader(outputStream, args, sources);
     for (Rule rule : rules) {
       outputStream.println(formatMavenJar(rule, "maven_jar", ""));
     }
@@ -91,7 +93,7 @@ public class WorkspaceWriter extends AbstractWriter {
 
   public void writeBuild(PrintStream outputStream, List<String> sources,
       Collection<Rule> rules) {
-    writeHeader(outputStream, sources);
+    writeHeader(outputStream, args, sources);
     for (Rule rule : rules) {
       outputStream.println(formatJavaLibrary(rule, "java_library", ""));
     }

--- a/generate_workspace/src/test/java/com/google/devtools/build/workspace/output/BzlWriterTest.java
+++ b/generate_workspace/src/test/java/com/google/devtools/build/workspace/output/BzlWriterTest.java
@@ -34,7 +34,7 @@ public class BzlWriterTest {
 
   @Test
   public void writeEmpty() throws Exception {
-    BzlWriter writer = new BzlWriter(System.getenv("TEST_TMPDIR"));
+    BzlWriter writer = new BzlWriter(new String[]{}, System.getenv("TEST_TMPDIR"));
     writer.write(ImmutableList.of(), ImmutableList.of());
     String fileContents = Files.toString(
         new File(System.getenv("TEST_TMPDIR") + "/generate_workspace.bzl"),
@@ -45,7 +45,7 @@ public class BzlWriterTest {
 
   @Test
   public void writeRules() throws Exception {
-    BzlWriter writer = new BzlWriter(System.getenv("TEST_TMPDIR"));
+    BzlWriter writer = new BzlWriter(new String[]{}, System.getenv("TEST_TMPDIR"));
     writer.write(ImmutableList.of(), ImmutableList.of(
         new Rule(new DefaultArtifact("x:y:1.2.3"))
     ));
@@ -63,5 +63,15 @@ public class BzlWriterTest {
         + "          \"@x_y//jar\",\n"
         + "      ],\n"
         + "  )\n");
+  }
+
+  @Test
+  public void writeCommand() throws Exception {
+    BzlWriter writer = new BzlWriter(new String[]{"x", "y", "z"}, System.getenv("TEST_TMPDIR"));
+    writer.write(ImmutableList.of(), ImmutableList.of());
+    String fileContents = Files.toString(
+        new File(System.getenv("TEST_TMPDIR") + "/generate_workspace.bzl"),
+        Charset.defaultCharset());
+    assertThat(fileContents).contains("# generate_workspace x y z");
   }
 }

--- a/generate_workspace/src/test/java/com/google/devtools/build/workspace/output/WorkspaceWriterTest.java
+++ b/generate_workspace/src/test/java/com/google/devtools/build/workspace/output/WorkspaceWriterTest.java
@@ -41,7 +41,7 @@ public class WorkspaceWriterTest {
   public String getWorkspaceFileContent(List<String> sources, Set<Rule> rules) throws Exception {
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     PrintStream ps = new PrintStream(baos);
-    WorkspaceWriter writer = new WorkspaceWriter(System.getenv("TEST_TMPDIR"));
+    WorkspaceWriter writer = new WorkspaceWriter(new String[]{}, System.getenv("TEST_TMPDIR"));
     writer.writeWorkspace(ps, sources, rules);
     return baos.toString(String.valueOf(Charset.defaultCharset()));
   }
@@ -49,7 +49,7 @@ public class WorkspaceWriterTest {
   public String getBuildFileContent(List<String> sources, Set<Rule> rules) throws Exception {
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     PrintStream ps = new PrintStream(baos);
-    WorkspaceWriter writer = new WorkspaceWriter(System.getenv("TEST_TMPDIR"));
+    WorkspaceWriter writer = new WorkspaceWriter(new String[]{}, System.getenv("TEST_TMPDIR"));
     writer.writeBuild(ps, sources, rules);
     return baos.toString(String.valueOf(Charset.defaultCharset()));
   }


### PR DESCRIPTION
We've heard from users who run generate_workspace multiple times.
Keeping a record of the command run should make it easier to
regenerate the WORKSPACE file and slightly modify the input, if
needed.