### PR TITLE
Add back in local range resolution

### DIFF
--- a/generate_workspace/src/main/java/com/google/devtools/build/workspace/maven/Aether.java
+++ b/generate_workspace/src/main/java/com/google/devtools/build/workspace/maven/Aether.java
@@ -69,7 +69,11 @@ public class Aether {
   /** Given an artifacts requests a version range for it. */
   List<String> requestVersionRange(Artifact artifact) throws VersionRangeResolutionException {
     VersionRangeRequest rangeRequest = new VersionRangeRequest(artifact, remoteRepositories, null);
-    VersionRangeResult result = repositorySystem.resolveVersionRange(repositorySystemSession, rangeRequest);
+    VersionRangeResult result = repositorySystem.resolveVersionRange(
+        repositorySystemSession, rangeRequest);
+    if (!result.getExceptions().isEmpty()) {
+      throw new VersionRangeResolutionException(result);
+    }
     return result.getVersions().stream().map(Version::toString).collect(toList());
   }
 

--- a/generate_workspace/src/main/java/com/google/devtools/build/workspace/maven/DefaultModelResolver.java
+++ b/generate_workspace/src/main/java/com/google/devtools/build/workspace/maven/DefaultModelResolver.java
@@ -126,12 +126,28 @@ public class DefaultModelResolver implements ModelResolver {
   private UrlModelSource getModelSource(
       String url, String groupId, String artifactId, String version)
       throws UnresolvableModelException {
+    // First just try the specified version.
+    String parsedVersion = VersionResolver.resolveVersionLocally(version);
+
+    if (parsedVersion != null) {
+      UrlModelSource source = getUrlModelSource(url, groupId, artifactId, parsedVersion);
+      if (source != null) {
+        return source;
+      }
+    }
+
+    // Go to town looking for a valid version.
     try {
       version = versionResolver.resolveVersion(groupId, artifactId, version);
     } catch (ArtifactBuilder.InvalidArtifactCoordinateException e) {
       throw new UnresolvableModelException(
           "Unable to resolve version", groupId, artifactId, version, e);
     }
+    return getUrlModelSource(url, groupId, artifactId, version);
+  }
+
+  private UrlModelSource getUrlModelSource(String url, String groupId, String artifactId,
+      String version) throws UnresolvableModelException {
     try {
       if (!url.endsWith("/")) {
         url += "/";

--- a/generate_workspace/src/test/java/com/google/devtools/build/workspace/maven/VersionResolverTest.java
+++ b/generate_workspace/src/test/java/com/google/devtools/build/workspace/maven/VersionResolverTest.java
@@ -118,4 +118,27 @@ public class VersionResolverTest {
     assertThat(isVersionRange("3.0")).isFalse();
   }
 
+  @Test
+  public void localSoftPin() throws Exception {
+    String version = VersionResolver.resolveVersionLocally("1.0");
+    assertThat(version).isEqualTo("1.0");
+  }
+
+  @Test
+  public void localHardPin() throws Exception {
+    String version = VersionResolver.resolveVersionLocally("[1.0]");
+    assertThat(version).isEqualTo("1.0");
+  }
+
+  @Test
+  public void localRange() throws Exception {
+    String version = VersionResolver.resolveVersionLocally("[1.0,2.0]");
+    assertThat(version).isEqualTo("2.0");
+  }
+
+  @Test
+  public void localUnresolvable() throws Exception {
+    String version = VersionResolver.resolveVersionLocally("(1.0,2.0)");
+    assertThat(version).isNull();
+  }
 }


### PR DESCRIPTION
If an artifact wants a version and it's resolvable, just use
that version. Don't make an extra round trip to fetch versions
unless the requested version doesn't work out.

Fixes #47.