### PR TITLE
Add quiet option to transitive_maven_jar rule

### DIFF
--- a/transitive_maven_jar/transitive_maven_jar.bzl
+++ b/transitive_maven_jar/transitive_maven_jar.bzl
@@ -15,23 +15,25 @@ def _create_arguments(rctx):
     arguments = ['--artifact ' + artifact for artifact in rctx.attr.artifacts]
     return ' '.join(arguments)
 
-def _execute(rctx, command_string):
-    return rctx.execute(["bash", "-c", command_string], timeout = rctx.attr._timeout, quiet = False)
+def _execute(rctx, command_string, quiet):
+    return rctx.execute(["bash", "-c", command_string], timeout = rctx.attr._timeout, quiet = quiet)
 
 def _transitive_maven_jar_impl(rctx):
     _validate_coordinates(rctx)
     arguments = _create_arguments(rctx)
+    quiet = rctx.attr.quiet
 
     jar_path = rctx.path(rctx.attr._generate_workspace_tool)
 
     # execute the command
-    result = _execute(rctx, "java -jar %s %s" % (jar_path, arguments))
+    result = _execute(rctx, "java -jar %s %s" % (jar_path, arguments), quiet)
     rctx.file('%s/BUILD' % rctx.path(''), '', False)
 
 transitive_maven_jar = repository_rule(
         implementation = _transitive_maven_jar_impl,
         attrs = {
             "artifacts" : attr.string_list(default = [], mandatory = True),
+            "quiet" : attr.bool(default = False, mandatory = False),
             "_timeout" : attr.int(default = MAX_TIMEOUT),
 			"_generate_workspace_tool" : attr.label(executable = True, allow_files = True, cfg = "host", default = Label("//transitive_maven_jar:generate_workspace_deploy.jar"))
 			#TODO(petros): add support for private repositories.


### PR DESCRIPTION
Excessive output to stdout from the transitive_maven_jar rule can throw
off the Bazel IntelliJ plugin and cause the project to fail to sync. See
also (b/65344142).