### PR TITLE
Implement ModelResolver.addRepository(Repository, boolean) correctly.

### DIFF
--- a/generate_workspace/src/main/java/com/google/devtools/build/workspace/maven/DefaultModelResolver.java
+++ b/generate_workspace/src/main/java/com/google/devtools/build/workspace/maven/DefaultModelResolver.java
@@ -182,12 +182,19 @@ public class DefaultModelResolver implements ModelResolver {
   // For compatibility with older versions of ModelResolver which don't have this method,
   // don't add @Override.
   public void addRepository(Repository repository) {
-    repositories.add(repository);
+    addRepository(repository, false);
   }
 
   @Override
   public void addRepository(Repository repository, boolean replace) {
-    addRepository(repository);
+    if (repositories.contains(repository)) {
+      if (replace) {
+        repositories.remove(repository);
+        repositories.add(repository);
+      }
+    } else {
+      repositories.add(repository);
+    }
   }
 
   @Override

--- a/generate_workspace/src/test/java/com/google/devtools/build/workspace/maven/BUILD
+++ b/generate_workspace/src/test/java/com/google/devtools/build/workspace/maven/BUILD
@@ -36,6 +36,17 @@ java_test(
 )
 
 java_test(
+    name = "DefaultModelResolverTest",
+    srcs = ["DefaultModelResolverTest.java"],
+    deps = [
+        "//generate_workspace/src/main/java/com/google/devtools/build/workspace/maven",
+        "//third_party:com_google_truth_truth",
+        "//third_party:junit_junit",
+        "//third_party:maven_model",
+    ],
+)
+
+java_test(
     name = "GraphSerializerTest",
     srcs = ["GraphSerializerTest.java"],
     deps = [

--- a/generate_workspace/src/test/java/com/google/devtools/build/workspace/maven/DefaultModelResolverTest.java
+++ b/generate_workspace/src/test/java/com/google/devtools/build/workspace/maven/DefaultModelResolverTest.java
@@ -1,0 +1,71 @@
+package com.google.devtools.build.workspace.maven;
+
+import org.apache.maven.model.Repository;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import static com.google.common.truth.Truth.assertThat;
+
+/**
+ * Tests for {@link DefaultModelResolver}.
+ */
+@RunWith(JUnit4.class)
+public class DefaultModelResolverTest {
+  /** Test that addRepository doesn't replace existing repositories by default. */
+  @Test
+  public void testAddRepository_defaultReplace() {
+    Repository repoA1 = new Repository();
+    repoA1.setId("repoA");
+    repoA1.setUrl("url:1");
+    Repository repoA2 = new Repository();
+    repoA2.setId("repoA");
+    repoA2.setUrl("url:2");
+
+    DefaultModelResolver testResolver = new DefaultModelResolver();
+    testResolver.addRepository(repoA1);
+    assertThat(testResolver.repositoriesById).containsKey(repoA1.getId());
+    testResolver.addRepository(repoA2);
+    assertThat(testResolver.repositoriesById).containsKey(repoA1.getId());
+    // URL should not have changed.
+    assertThat(testResolver.repositoriesById.get(repoA1.getId()).getUrl()).isEqualTo("url:1");
+  }
+
+  /** Test that addRepository doesn't replace existing repositories when replace is false. */
+  @Test
+  public void testAddRepository_falseReplace() {
+    Repository repoA1 = new Repository();
+    repoA1.setId("repoA");
+    repoA1.setUrl("url:1");
+    Repository repoA2 = new Repository();
+    repoA2.setId("repoA");
+    repoA2.setUrl("url:2");
+
+    DefaultModelResolver testResolver = new DefaultModelResolver();
+    testResolver.addRepository(repoA1);
+    assertThat(testResolver.repositoriesById).containsKey(repoA1.getId());
+    testResolver.addRepository(repoA2, false);
+    assertThat(testResolver.repositoriesById).containsKey(repoA1.getId());
+    // URL should not have changed.
+    assertThat(testResolver.repositoriesById.get(repoA1.getId()).getUrl()).isEqualTo("url:1");
+  }
+
+  /** Test that addRepository does replace existing repositories when replace is true. */
+  @Test
+  public void testAddRepository_trueReplace() {
+    Repository repoA1 = new Repository();
+    repoA1.setId("repoA");
+    repoA1.setUrl("url:1");
+    Repository repoA2 = new Repository();
+    repoA2.setId("repoA");
+    repoA2.setUrl("url:2");
+
+    DefaultModelResolver testResolver = new DefaultModelResolver();
+    testResolver.addRepository(repoA1);
+    assertThat(testResolver.repositoriesById).containsKey(repoA1.getId());
+    testResolver.addRepository(repoA2, true);
+    assertThat(testResolver.repositoriesById).containsKey(repoA1.getId());
+    // URL should have changed.
+    assertThat(testResolver.repositoriesById.get(repoA1.getId()).getUrl()).isEqualTo("url:2");
+  }
+}


### PR DESCRIPTION
This correctly honors the `replace` parameter. It was ignored before, which was making it effectively be treated as `false`.

Per [the reference implementation](https://github.com/apache/maven/blob/542a7a89156263b34d1472e9d9c1a2795afccd2d/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/DefaultModelResolver.java#L113-L144), the single-argument `addRepository` should not replace (although it wasn't before).