### PR TITLE
Remove no-op setter calls.

### DIFF
--- a/generate_workspace/src/main/java/com/google/devtools/build/workspace/maven/DefaultModelResolver.java
+++ b/generate_workspace/src/main/java/com/google/devtools/build/workspace/maven/DefaultModelResolver.java
@@ -41,10 +41,6 @@ import org.apache.maven.model.building.ModelBuildingException;
 import org.apache.maven.model.building.ModelBuildingResult;
 import org.apache.maven.model.building.ModelSource;
 import org.apache.maven.model.building.UrlModelSource;
-import org.apache.maven.model.composition.DefaultDependencyManagementImporter;
-import org.apache.maven.model.management.DefaultDependencyManagementInjector;
-import org.apache.maven.model.management.DefaultPluginManagementInjector;
-import org.apache.maven.model.plugin.DefaultPluginConfigurationExpander;
 import org.apache.maven.model.profile.DefaultProfileSelector;
 import org.apache.maven.model.resolution.ModelResolver;
 import org.apache.maven.model.resolution.UnresolvableModelException;
@@ -79,10 +75,6 @@ public class DefaultModelResolver implements ModelResolver {
         Maps.newHashMap(),
         new DefaultModelBuilderFactory().newInstance()
             .setProfileSelector(new DefaultProfileSelector())
-            .setPluginConfigurationExpander(new DefaultPluginConfigurationExpander())
-            .setPluginManagementInjector(new DefaultPluginManagementInjector())
-            .setDependencyManagementImporter(new DefaultDependencyManagementImporter())
-            .setDependencyManagementInjector(new DefaultDependencyManagementInjector())
     );
   }
 


### PR DESCRIPTION
These all duplicate the defaults in [`DefaultModelBuilderFactory`](https://github.com/apache/maven/blob/maven-3.5.0/maven-model-builder/src/main/java/org/apache/maven/model/building/DefaultModelBuilderFactory.java).