### PR TITLE
Switch output from System.out to System.err

### DIFF
--- a/generate_workspace/src/main/java/com/google/devtools/build/workspace/GenerateWorkspace.java
+++ b/generate_workspace/src/main/java/com/google/devtools/build/workspace/GenerateWorkspace.java
@@ -48,7 +48,7 @@ public class GenerateWorkspace {
     try {
       optionParser.parse(args);
     } catch (ParameterException e) {
-      System.out.println("Unable to parse options: " + e.getLocalizedMessage());
+      System.err.println("Unable to parse options: " + e.getLocalizedMessage());
       optionParser.usage();
       return;
     }

--- a/generate_workspace/src/main/java/com/google/devtools/build/workspace/output/BzlWriter.java
+++ b/generate_workspace/src/main/java/com/google/devtools/build/workspace/output/BzlWriter.java
@@ -57,7 +57,7 @@ public class BzlWriter extends AbstractWriter {
       logger.severe("Could not write " + generatedFile + ": " + e.getMessage());
       return;
     }
-    System.out.println("Wrote " + generatedFile.toAbsolutePath());
+    System.err.println("Wrote " + generatedFile.toAbsolutePath());
   }
 
   private void writeBzl(PrintStream outputStream, Collection<Rule> rules) {

--- a/generate_workspace/src/main/java/com/google/devtools/build/workspace/output/WorkspaceWriter.java
+++ b/generate_workspace/src/main/java/com/google/devtools/build/workspace/output/WorkspaceWriter.java
@@ -76,7 +76,7 @@ public class WorkspaceWriter extends AbstractWriter {
               + e.getMessage());
       return;
     }
-    System.out.println("Wrote:\n" + workspaceFile + "\n" + buildFile);
+    System.err.println("Wrote:\n" + workspaceFile + "\n" + buildFile);
   }
 
   /**


### PR DESCRIPTION
We have tried to start using the new `transitive_maven_jar` but ran into a weird case. The migration-tooling stuff will regenerate the `generate_workspace.bzl` on the first bazel command after changing the WORKSPACE. In our case, we ran a `bazel query ... | grep` thing and noticed that this showed up in the output (breaking our tooling):
```
Wrote /home/admin/.cache/bazel/_bazel_admin/61e657d6884c63362b8b441914a1bc68/external/dependencies/generate_workspace.bzl
```
This pull request changes all of the `System.out` calls to `System.err` to avoid this kind of issue in the future. I noticed that the deploy jar was checked in, so I ran this as well, but I'm not sure if there is a better process:
```
bazel build //generate_workspace:generate_workspace_deploy.jar && cp bazel-bin/generate_workspace/generate_workspace_deploy.jar transitive_maven_jar/
```
