### PR TITLE
set Repository ID

### DIFF
--- a/generate_workspace/src/main/java/com/google/devtools/build/workspace/maven/DefaultModelResolver.java
+++ b/generate_workspace/src/main/java/com/google/devtools/build/workspace/maven/DefaultModelResolver.java
@@ -82,6 +82,7 @@ public class DefaultModelResolver implements ModelResolver {
             .map(
                 (String url) -> {
                   Repository r = new Repository();
+                  r.setId(url);
                   r.setUrl(url);
                   return r;
                 })


### PR DESCRIPTION
`Repository` checks `getId` for equality http://grepcode.com/file/repo1.maven.org/maven2/org.apache.maven/maven-model/3.3.3/org/apache/maven/model/RepositoryBase.java#RepositoryBase.equals%28java.lang.Object%29

Without this, the `toSet` always end up with 1 repo https://github.com/bazelbuild/migration-tooling/pull/76/files#diff-4518b099acd871fca1a03fff14b3df1bL88