### PR TITLE
Avoid dyndns.org lookup

### DIFF
--- a/generate_workspace/src/main/java/com/google/devtools/build/workspace/maven/DefaultModelResolver.java
+++ b/generate_workspace/src/main/java/com/google/devtools/build/workspace/maven/DefaultModelResolver.java
@@ -26,7 +26,9 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -44,6 +46,8 @@ import org.eclipse.aether.repository.RemoteRepository;
 
 /** Resolver to find the repository a given Maven artifact should be fetched from. */
 public class DefaultModelResolver implements ModelResolver {
+
+  public static Set<String> REPOSITORY_BLACKLIST = new HashSet<>(Arrays.asList("maven.dyndns.org"));
 
   private static final Logger logger =
       Logger.getLogger(MethodHandles.lookup().lookupClass().getName());
@@ -168,6 +172,12 @@ public class DefaultModelResolver implements ModelResolver {
                   + "-"
                   + version
                   + ".pom");
+
+      // skip blacklisted ones
+      if (REPOSITORY_BLACKLIST.contains(urlUrl.getHost())) {
+        return null;
+      }
+
       if (pomFileExists(urlUrl)) {
         UrlModelSource urlModelSource = new UrlModelSource(urlUrl);
         ruleNameToModelSource.put(Rule.name(groupId, artifactId), urlModelSource);

--- a/generate_workspace/src/main/java/com/google/devtools/build/workspace/maven/DefaultModelResolver.java
+++ b/generate_workspace/src/main/java/com/google/devtools/build/workspace/maven/DefaultModelResolver.java
@@ -29,6 +29,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -90,7 +91,7 @@ public class DefaultModelResolver implements ModelResolver {
                   r.setUrl(url);
                   return r;
                 })
-            .collect(Collectors.toSet()),
+            .collect(Collectors.toCollection(LinkedHashSet::new)),
         Maps.newHashMap(),
         new DefaultModelBuilderFactory()
             .newInstance()


### PR DESCRIPTION
dyndns.org is broken and doesn't give any response. We have a couple hundred dependencies and this the url connection won't stop until it times out after like 30 seconds. This results in that the entire dependency generation process takes longer than a couple hours.

We should avoid trying to download pom file from their site. Adding a simple blacklist can fix this issue.