### PR TITLE
Added duplicate check for generated Maven jars+libs

### DIFF
--- a/generate_workspace/src/main/java/com/google/devtools/build/workspace/output/AbstractWriter.java
+++ b/generate_workspace/src/main/java/com/google/devtools/build/workspace/output/AbstractWriter.java
@@ -45,18 +45,19 @@ public abstract class AbstractWriter {
     for (String parent : rule.getParents()) {
       builder.append(indent).append("# ").append(parent).append("\n");
     }
-    builder.append(indent).append(ruleName).append("(\n");
-    builder.append(indent).append("    name = \"").append(rule.name()).append("\",\n");
-    builder.append(indent).append("    artifact = \"").append(rule.toMavenArtifactString())
+    builder.append(indent).append("if \"").append(rule.name()).append("\" not in excludes:\n");
+    builder.append(indent).append("  ").append(ruleName).append("(\n");
+    builder.append(indent).append("  ").append("    name = \"").append(rule.name()).append("\",\n");
+    builder.append(indent).append("  ").append("    artifact = \"").append(rule.toMavenArtifactString())
         .append("\",\n");
     if (rule.hasCustomRepository()) {
-      builder.append(indent).append("    repository = \"").append(rule.getRepository())
+      builder.append(indent).append("  ").append("    repository = \"").append(rule.getRepository())
           .append("\",\n");
     }
     if (rule.getSha1() != null) {
-      builder.append(indent).append("    sha1 = \"").append(rule.getSha1()).append("\",\n");
+      builder.append(indent).append("  ").append("    sha1 = \"").append(rule.getSha1()).append("\",\n");
     }
-    builder.append(indent).append(")\n\n");
+    builder.append(indent).append("  ").append(")\n\n");
     return builder.toString();
   }
 
@@ -65,19 +66,20 @@ public abstract class AbstractWriter {
    */
   protected String formatJavaLibrary(Rule rule, String ruleName, String indent) {
     StringBuilder builder = new StringBuilder();
-    builder.append(indent).append(ruleName).append("(\n");
-    builder.append(indent).append("    name = \"").append(rule.name()).append("\",\n");
-    builder.append(indent).append("    visibility = [\"//visibility:public\"],\n");
-    builder.append(indent).append("    exports = [\"@").append(rule.name()).append("//jar\"],\n");
+    builder.append(indent).append("if \"").append(rule.name()).append("\" not in excludes:\n");
+    builder.append(indent).append("  ").append(ruleName).append("(\n");
+    builder.append(indent).append("  ").append("    name = \"").append(rule.name()).append("\",\n");
+    builder.append(indent).append("  ").append("    visibility = [\"//visibility:public\"],\n");
+    builder.append(indent).append("  ").append("    exports = [\"@").append(rule.name()).append("//jar\"],\n");
     Set<Rule> dependencies = rule.getDependencies();
     if (!dependencies.isEmpty()) {
-      builder.append(indent).append("    runtime_deps = [\n");
+      builder.append(indent).append("  ").append("    runtime_deps = [\n");
       for (Rule r : rule.getDependencies()) {
-        builder.append(indent).append("        \":").append(r.name()).append("\",\n");
+        builder.append(indent).append("  ").append("        \":").append(r.name()).append("\",\n");
       }
-      builder.append(indent).append("    ],\n");
+      builder.append(indent).append("  ").append("    ],\n");
     }
-    builder.append(indent).append(")\n\n");
+    builder.append(indent).append("  ").append(")\n\n");
     return builder.toString();
   }
 }

--- a/generate_workspace/src/main/java/com/google/devtools/build/workspace/output/BzlWriter.java
+++ b/generate_workspace/src/main/java/com/google/devtools/build/workspace/output/BzlWriter.java
@@ -66,6 +66,7 @@ public class BzlWriter extends AbstractWriter {
     if (rules.isEmpty()) {
       outputStream.println("  pass\n");
     }
+    outputStream.println("  excludes = native.existing_rules().keys()\n");
     for (Rule rule : rules) {
       outputStream.println(formatMavenJar(rule, "native.maven_jar", "  "));
     }
@@ -76,6 +77,7 @@ public class BzlWriter extends AbstractWriter {
     if (rules.isEmpty()) {
       outputStream.println("  pass\n");
     }
+    outputStream.println("  excludes = native.existing_rules().keys()\n");
     for (Rule rule : rules) {
       outputStream.println(formatJavaLibrary(rule, "native.java_library", "  "));
     }

--- a/generate_workspace/src/main/java/com/google/devtools/build/workspace/output/WorkspaceWriter.java
+++ b/generate_workspace/src/main/java/com/google/devtools/build/workspace/output/WorkspaceWriter.java
@@ -84,6 +84,7 @@ public class WorkspaceWriter extends AbstractWriter {
    */
   public void writeWorkspace(PrintStream outputStream, Collection<Rule> rules) {
     writeHeader(outputStream, args);
+    outputStream.println("excludes = native.existing_rules().keys()\n");
     for (Rule rule : rules) {
       outputStream.println(formatMavenJar(rule, "maven_jar", ""));
     }
@@ -91,6 +92,7 @@ public class WorkspaceWriter extends AbstractWriter {
 
   public void writeBuild(PrintStream outputStream, Collection<Rule> rules) {
     writeHeader(outputStream, args);
+    outputStream.println("excludes = native.existing_rules().keys()\n");
     for (Rule rule : rules) {
       outputStream.println(formatJavaLibrary(rule, "java_library", ""));
     }

--- a/generate_workspace/src/test/java/com/google/devtools/build/workspace/output/BzlWriterTest.java
+++ b/generate_workspace/src/test/java/com/google/devtools/build/workspace/output/BzlWriterTest.java
@@ -87,15 +87,25 @@ public class BzlWriterTest {
     String fileContents = Files.toString(
         new File(System.getenv("TEST_TMPDIR") + "/generate_workspace.bzl"),
         Charset.defaultCharset());
-    assertThat(fileContents).contains("def generated_maven_jars():\n  native.maven_jar(\n"
-        + "      name = \"x_y\",\n"
-        + "      artifact = \"x:y:1.2.3\",\n"
-        + "  )\n");
-    assertThat(fileContents).contains("def generated_java_libraries():\n  native.java_library(\n"
-        + "      name = \"x_y\",\n"
-        + "      visibility = [\"//visibility:public\"],\n"
-        + "      exports = [\"@x_y//jar\"],\n"
-        + "  )\n");
+    assertThat(fileContents).contains(
+            "def generated_maven_jars():\n"
+          + "  excludes = native.existing_rules().keys()\n\n"
+          + "  if \"x_y\" not in excludes:\n"
+          + "    native.maven_jar(\n"
+          + "        name = \"x_y\",\n"
+          + "        artifact = \"x:y:1.2.3\",\n"
+          + "    )\n"
+    );
+    assertThat(fileContents).contains(
+            "def generated_java_libraries():\n"
+          + "  excludes = native.existing_rules().keys()\n\n"
+          + "  if \"x_y\" not in excludes:\n"
+          + "    native.java_library(\n"
+          + "        name = \"x_y\",\n"
+          + "        visibility = [\"//visibility:public\"],\n"
+          + "        exports = [\"@x_y//jar\"],\n"
+          + "    )\n"
+    );
   }
 
   @Test


### PR DESCRIPTION
Added some logic to the writer files for the `generate_workspace` target to allow for ignoring of already-loaded Maven jars/libraries. This change always ignores by default, don't know if this is something that would be preferable to be able to opt into/out of? 

Followed the logic that was made to allow for something similar in `rules_docker` here: https://github.com/bazelbuild/rules_docker/pull/84

Found this helpful for a Maven project that contained multiple subprojects containing shared dependencies and running into errors based on those collisions. 