### PR TITLE
Mark as deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# DEPRECATED
+
+This project is deprecated. Use [build-deps](https://github.com/johnynek/bazel-deps) instead.
+
 [![Build status](https://badge.buildkite.com/3d265f4a4ef0aa6c54208278c5062491bb074298069d30b051.svg)](https://buildkite.com/bazel/migration-tooling-postsubmit)
 
 # Migration tooling


### PR DESCRIPTION
This project appears to be dead, with an official successor in [bazel-deps](https://github.com/johnynek/bazel-deps) (see [this comment](https://github.com/bazelbuild/migration-tooling/issues/83#issuecomment-374715476)). Users are, however, sent here by [the official Bazel documentation](https://docs.bazel.build/versions/master/generate-workspace.html). This wastes everybody's time, and erodes trust in the bazel ecosystem.

This PR marks the repository as deprecated, and redirects visitors to the bazel-deps repo.

If this project is still maintained, and the comment referenced above is wrong, then please disregard this PR.